### PR TITLE
qtwebchannel 6.7.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+aggregate_check: false
+
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,24 @@
+@REM https://bugreports.qt.io/browse/QTBUG-107009
+set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
+
+cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DINSTALL_BINDIR=lib/qt6/bin ^
+    -DINSTALL_PUBLICBINDIR=bin ^
+    -DINSTALL_LIBEXECDIR=lib/qt6 ^
+    -DINSTALL_DOCDIR=share/doc/qt6 ^
+    -DINSTALL_ARCHDATADIR=lib/qt6 ^
+    -DINSTALL_DATADIR=share/qt6 ^
+    -DINSTALL_INCLUDEDIR=include/qt6 ^
+    -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs ^
+    -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples ^
+    -DINSTALL_DATADIR=share/qt6
+if errorlevel 1 exit 1
+
+cmake --build build --target install
+if errorlevel 1 exit 1
+
+xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+export LD_LIBRARY_PATH="${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64:${BUILD_PREFIX}/${HOST}/sysroot/usr/lib:${LD_LIBRARY_PATH}"
+
+cmake -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
+  -DCMAKE_PREFIX_PATH=${PREFIX} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \
+  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+  -DCMAKE_FIND_FRAMEWORK=LAST \
+  -DBUILD_WITH_PCH=OFF \
+  -DINSTALL_BINDIR=lib/qt6/bin \
+  -DINSTALL_PUBLICBINDIR=bin \
+  -DINSTALL_LIBEXECDIR=lib/qt6 \
+  -DINSTALL_DOCDIR=share/doc/qt6 \
+  -DINSTALL_ARCHDATADIR=lib/qt6 \
+  -DINSTALL_DATADIR=share/qt6 \
+  -DINSTALL_INCLUDEDIR=include/qt6 \
+  -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs \
+  -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples
+cmake --build build --target install
+
+pushd "${PREFIX}"
+
+mkdir -p bin
+
+if [[ -f "${SRC_DIR}"/build/user_facing_tool_links.txt ]]; then
+  for links in "${SRC_DIR}"/build/user_facing_tool_links.txt; do
+    while read _line; do
+      if [[ -n "${_line}" ]]; then
+        ln -sf ${_line}
+      fi
+    done < ${links}
+  done
+fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,11 @@
+MACOSX_SDK_VERSION:
+  - '11.3'                                                   # [osx]
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
+c_compiler:
+  - vs2019  # [win]
+cxx_compiler:
+  - vs2019  # [win]
+macos_machine:
+  - x86_64-apple-darwin20.0.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,118 @@
+{% set name = "qtwebchannel" %}
+{% set version = "6.7.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: ac5d96607b10e7de546eaf93bb9f65c0fd631ef9b91ef8a794e26fd57db4501c
+    folder: {{ name }}
+
+build:
+  number: 0
+  skip: True  # [ppc64le or s390x]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('libdrm-devel') }}               # [linux]
+    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
+    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
+    - {{ cdt('libice-devel') }}               # [linux]
+    - {{ cdt('libsm-devel') }}                # [linux]
+    - {{ cdt('libx11-devel') }}               # [linux]
+    - {{ cdt('libxau-devel') }}               # [linux]
+    - {{ cdt('mesa-libgl-devel') }}           # [linux]
+    - {{ cdt('mesa-libgbm') }}                # [linux]
+    - {{ cdt('mesa-libegl-devel') }}          # [linux]
+    - {{ cdt('mesa-dri-drivers') }}           # [linux]
+    - {{ cdt('xcb-util-devel') }}             # [linux]
+    - {{ cdt('xcb-util-image-devel') }}       # [linux]
+    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
+    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
+    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
+    - {{ cdt('libselinux') }}                 # [linux]
+    - {{ cdt('libxext') }}                    # [linux]
+    - {{ cdt('libxdamage') }}                 # [linux]
+    - {{ cdt('libxfixes') }}                  # [linux]
+    - {{ cdt('libxxf86vm') }}                 # [linux]
+    - pkg-config  # [unix]
+    - bison       # [linux]
+    - flex        # [linux]
+    - gperf       # [linux]
+    - jom         # [win]
+    - m2-bison    # [win]
+    - m2-flex     # [win]
+    - m2-gperf    # [win]
+    - cmake
+    - ninja
+    - perl
+
+  host:
+    - qtbase {{ version }}
+    - qtdeclarative {{ version }}
+
+  run_constrained:
+    - qt-main >={{ version }},<7
+    - qt >={{ version }},<7
+
+test:
+  requires:
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - {{ cdt('libdrm-devel') }}               # [linux]
+    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
+    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
+    - {{ cdt('libice-devel') }}               # [linux]
+    - {{ cdt('libsm-devel') }}                # [linux]
+    - {{ cdt('libx11-devel') }}               # [linux]
+    - {{ cdt('libxau-devel') }}               # [linux]
+    - {{ cdt('mesa-libgl-devel') }}           # [linux]
+    - {{ cdt('mesa-libgbm') }}                # [linux]
+    - {{ cdt('mesa-libegl-devel') }}          # [linux]
+    - {{ cdt('mesa-dri-drivers') }}           # [linux]
+    - {{ cdt('xcb-util-devel') }}             # [linux]
+    - {{ cdt('xcb-util-image-devel') }}       # [linux]
+    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
+    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
+    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
+    - {{ cdt('libselinux') }}                 # [linux]
+    - {{ cdt('libxext') }}                    # [linux]
+    - {{ cdt('libxdamage') }}                 # [linux]
+    - {{ cdt('libxfixes') }}                  # [linux]
+    - {{ cdt('libxxf86vm') }}                 # [linux]
+  files:
+    - run_qt_test.sh    # [unix]
+    - run_qt_test.bat   # [win]
+    - test/test_qtwebchannel.cpp
+    - test/CMakeLists.txt
+  commands:
+    - ./run_qt_test.sh  # [unix]
+    - run_qt_test.bat   # [win]
+    {% for each_qt_lib in ["WebChannel", "WebChannelQuick"] %}
+    - test -d $PREFIX/include/qt6/Qt{{ each_qt_lib }}                           # [unix]
+    - test -f $PREFIX/lib/libQt6{{ each_qt_lib }}${SHLIB_EXT}                   # [unix]
+    - if not exist %PREFIX%\\Library\\include\\qt6\\Qt{{ each_qt_lib }} exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\Qt6{{ each_qt_lib }}.lib exit 1      # [win]
+    - if not exist %PREFIX%\\Library\\bin\\Qt6{{ each_qt_lib }}.dll exit 1      # [win]
+    {% endfor %}
+
+about:
+  home: https://www.qt.io/
+  license: LGPL-3.0-only
+  license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
+  license_family: LGPL
+  summary: Cross-platform application and UI framework ({{ name[2:] }} libraries).
+  description: |
+    Qt helps you create connected devices, UIs & applications that run
+    anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
+  doc_url: https://doc.qt.io/
+  dev_url: https://github.com/qt/{{ name }}

--- a/recipe/run_qt_test.bat
+++ b/recipe/run_qt_test.bat
@@ -1,0 +1,15 @@
+@ECHO ON
+
+if not exist %LIBRARY_BIN%\qt6.conf exit 1
+if not exist %PREFIX%\qt6.conf exit 1
+
+pushd test
+
+cmake -G"NMake Makefiles" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" .
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+ctest -C Release --output-on-failure
+if errorlevel 1 exit 1

--- a/recipe/run_qt_test.sh
+++ b/recipe/run_qt_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+export LD_LIBRARY_PATH="${PREFIX}/${HOST}/sysroot/usr/lib64:${PREFIX}/${HOST}/sysroot/usr/lib:${LD_LIBRARY_PATH}"
+
+test -f ${PREFIX}/bin/qt6.conf
+
+cmake -Stest -Bbuild -GNinja -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+cmake --build build --target all
+ctest --test-dir build --output-on-failure

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required (VERSION 3.0)
+
+set (CMAKE_BUILD_TYPE "Release" CACHE STRING "build type")
+
+project (qtwebchannel-test CXX)
+
+find_package (Qt6 CONFIG REQUIRED COMPONENTS WebChannel)
+
+add_executable (test_qtwebchannel test_qtwebchannel.cpp)
+target_link_libraries (test_qtwebchannel Qt6::WebChannel)
+
+enable_testing ()
+add_test (NAME test_qtwebchannel COMMAND test_qtwebchannel)

--- a/recipe/test/test_qtwebchannel.cpp
+++ b/recipe/test/test_qtwebchannel.cpp
@@ -1,0 +1,6 @@
+#include <QtWebChannel/QtWebChannel>
+
+int main() {
+    QWebChannel channel;
+    return (channel.propertyUpdateInterval() != 0)? 0: 1;
+}


### PR DESCRIPTION
qtwebchannel 6.7.2

**Destination channel:** defaults

### Links

- [PKG-5195](https://anaconda.atlassian.net/browse/PKG-5195) 
- [Upstream repository](https://github.com/qt/qtwebchannel)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4
  - https://github.com/AnacondaRecipes/tapi-feedstock/pull/3
  - https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/3
  - https://github.com/AnacondaRecipes/qtbase-feedstock/pull/2
  - https://github.com/AnacondaRecipes/qtdeclarative-feedstock/pull/1


### Explanation of changes:

- Major upgrade to qt 6.7.2, splitted qt-main into several recipes.


[PKG-5195]: https://anaconda.atlassian.net/browse/PKG-5195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ