### PR TITLE
qtwebchannel 6.7.3: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
-  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config  # [unix]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7775](https://anaconda.atlassian.net/browse/PKG-7775)
- [Upstream repository]()

### Explanation of changes:

-

### Notes:

- Automated migration/rebuild for group x11_gui_rebuilds.


[PKG-7775]: https://anaconda.atlassian.net/browse/PKG-7775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ