### PR TITLE
qtwebchannel 6.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
+  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
+  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/8aadcd5
+  - 

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,5 @@ channels:
   - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
   - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
   - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/8aadcd5
-  - 
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c
+  - https://staging.continuum.io/pbp/fs/qtwebsockets-feedstock/pr9/1fa36c1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
-  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
-  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c
-  - https://staging.continuum.io/pbp/fs/qtwebsockets-feedstock/pr9/1fa36c1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtwebchannel" %}
-{% set version = "6.10.2" %}
+{% set version = "6.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: e31ea59f8e19e0374d54fdc7a8479c840acffc4ba5297ee43564b5158a4f2c27
+    sha256: e946143a8b015e2c9d5cc6110515f43618b441799da546138d0b05d8afa9fb24
     folder: {{ name }}
 
 build:
@@ -63,7 +63,7 @@ test:
     - run_qt_test.bat   # [win]
 
 about:
-  home: https://www.qt.io/
+  home: https://www.qt.io
   license: LGPL-3.0-only
   license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
   license_family: LGPL
@@ -71,5 +71,5 @@ about:
   description: |
     Qt helps you create connected devices, UIs & applications that run
     anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
-  doc_url: https://doc.qt.io/
+  doc_url: https://doc.qt.io
   dev_url: https://github.com/qt/{{ name }}


### PR DESCRIPTION
qtwebchannel 6.11

**Destination channel:** defaults

### Links

- [PKG-11823](https://anaconda.atlassian.net/browse/PKG-11823) 
- [Upstream repository](https://github.com/qt/qtwebchannel/tree/v6.11.0)

### Explanation of changes:

- version update


[PKG-11823]: https://anaconda.atlassian.net/browse/PKG-11823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ